### PR TITLE
descriptions  + fixes

### DIFF
--- a/src/data/jokers/j_abraxas.lua
+++ b/src/data/jokers/j_abraxas.lua
@@ -1,18 +1,19 @@
+--TODO: booster pack thang
 function Balatrostuck.INIT.Jokers.j_abraxas()
     SMODS.Joker{
         name = "Abraxas",
         key = "abraxas",
         config = {
             extra = {
-                h_plays = 3,
-                h_size = 3
+                h_size = 4
             }
         },
         loc_txt = {
             ['name'] = 'Abraxas',
             ['text'] = {
-                [1] = '{C:blue}+#1#{} hands',
-                [2] = '{C:attention}+#2# hand size'
+                [1] = '{C:attention}+#1#{} hand size,',
+                [2] = '{C:attention}Booster Packs{} have',
+                [3] = '{C:attention}+#2#{} cards to choose from'
             }
         },
         pos = {
@@ -31,18 +32,18 @@ function Balatrostuck.INIT.Jokers.j_abraxas()
             y = 9
         },
         loc_vars = function(self, info_queue, card)
-            return {vars = {card.ability.extra.h_plays, card.ability.extra.h_size}}
+            return {vars = {card.ability.extra.h_size}}
         end,
 
 
         add_to_deck = function(self, card, from_debuff)
             G.hand:change_size(card.ability.extra.h_size)
-            G.GAME.round_resets.hands = G.GAME.round_resets.hands + card.ability.extra.h_plays
+
         end,
     
         remove_from_deck = function(self, card, from_debuff)
             G.hand:change_size(-card.ability.extra.h_size)
-            G.GAME.round_resets.hands = G.GAME.round_resets.hands - card.ability.extra.h_plays
+
         end
     }
     

--- a/src/data/jokers/j_aceDick.lua
+++ b/src/data/jokers/j_aceDick.lua
@@ -8,8 +8,8 @@ function Balatrostuck.INIT.Jokers.j_aceDick()
         end,   
         loc_txt = {
             name = 'Ace Dick',
-            text = {'{C:mult}+#1#{} mult and {C:chips}+#2#{} chips.',
-                    'Always triggers last.'}
+            text = {'{C:mult}+#1#{} Mult and {C:chips}+#2#{} Chips,',
+                    'always goes last'}
         },
         pos = {x = 7, y = 8},
         cost = 6,

--- a/src/data/jokers/j_ahabscrosshairs.lua
+++ b/src/data/jokers/j_ahabscrosshairs.lua
@@ -9,8 +9,10 @@ function Balatrostuck.INIT.Jokers.j_ahabscrosshairs()
         loc_txt = {
             ['name'] = 'Ahabs Crosshairs',
             ['text'] = {
-                [1] = "Gives X0.25 mult per 16$ of sell value",
-                [2] = "on all jokers. [Currently: 1x mult]."
+                [1] = "Gives {X:red,C:white}X#1#{} Mult per {C:money}$#2#",
+                [2] = "of total {C:attention}sell value",
+                [3] = "on all current {C:attention}Jokers",
+                [4] = "{C:inactive}(Currently {X:red,C:white}X#2#{C:inactive} Mult)."
             }
         },
         pos = {

--- a/src/data/jokers/j_aimlessrenegade.lua
+++ b/src/data/jokers/j_aimlessrenegade.lua
@@ -9,9 +9,10 @@ function Balatrostuck.INIT.Jokers.j_aimlessrenegade()
         loc_txt = {
             ['name'] = 'Aimless Renegade',
             ['text'] = {
-                [1] = "this effect",
-                [2] = "will likely be reworded in the",
-                [3] = "future"
+                [1] = "When {C:attention}Blind{} is selected, this Joker",
+                [2] = "gains {C:mult}+#1#{} Mult, {C:attention}destroys{} a random Joker,",
+                [3] = "and creates a {C:green}Paradox {C:attention}Judgement card",
+                [4] = "{C:inactive}(Currently {C:mult}+#2#{C:inactive} Mult)"
             }
         },
         pos = {

--- a/src/data/jokers/j_alltheirons.lua
+++ b/src/data/jokers/j_alltheirons.lua
@@ -9,6 +9,9 @@ function Balatrostuck.INIT.Jokers.j_alltheirons()
         loc_txt = {
             ['name'] = 'All the Irons',
             ['text'] = {
+                [1] = "Earn {C:money}$#1#{} if a Joker triggers",
+                [2] = "{C:attention}thrice{} in a single round",
+                [3] = "{C:inactive}(Once per Joker each round)"
             }
         },
         pos = {
@@ -23,7 +26,7 @@ function Balatrostuck.INIT.Jokers.j_alltheirons()
         discovered = true,
         atlas = 'HomestuckJokers',
 
-        calculate = function(self, context)
+        calculate = function(self, card, context)
         end
     }
 end

--- a/src/data/jokers/j_amberfirefly.lua
+++ b/src/data/jokers/j_amberfirefly.lua
@@ -9,10 +9,10 @@ function Balatrostuck.INIT.Jokers.j_amberfirefly()
         loc_txt = {
             ['name'] = 'Amber Firefly',
             ['text'] = {
-                [1] = "Place a paradox gold card",
-                [2] = "with a blue seal on the",
-                [3] = "bottom of the deck at",
-                [4] = "start of every round"
+                [1] = "Shuffle a random {C:green}Paradox",
+                [2] = "card with a {C:purple}Purple Seal{} into",
+                [3] = "deck when {C:attention}Blind{} is selected",
+                [4] = "{C:attention}-1{} hand size"
             }
         },
         pos = {

--- a/src/data/jokers/j_applejuice.lua
+++ b/src/data/jokers/j_applejuice.lua
@@ -8,9 +8,9 @@ function Balatrostuck.INIT.Jokers.j_applejuice()
         loc_txt = {
             ['name'] = 'Apple Juice',
             ['text'] = {
-                [1] = 'If no {C:red}discards{} remain',
-                [2] = 'add 1 extra {C:red}discard',
-                [3] = '{C:inactive}(#1# discards left)'
+                [1] = 'Gain {C:red}+1{} discard when',
+                [2] = '{C:attention}0{} discards remaining',
+                [3] = '{C:inactive}({C:attention}#1#{C:inactive} uses left)'
             }
         },
         pos = {
@@ -41,7 +41,7 @@ function Balatrostuck.INIT.Jokers.j_applejuice()
                         end
                     }))
                     return {
-                        message = localize('k_eaten_ex'),
+                        message = localize('k_drank_ex'),
                         colour = G.C.FILTER
                     }
                 else

--- a/src/data/jokers/j_ascend.lua
+++ b/src/data/jokers/j_ascend.lua
@@ -14,10 +14,9 @@ function Balatrostuck.INIT.Jokers.j_ascend()
         loc_txt = {
             ['name'] = 'Ascend',
             ['text'] = {
-                [1] = "Gains {C:mult}+#1# Mult{} per",
-                [2] = "unique {C:inactive}(rank-wise){}",
-                [3] = "{C:attention}#2#{} played",
-                [4] = "{C:inactive}(Currently: {}{C:mult}+#3# Mult{}{C:inactive}){}"
+                [1] = "This Joker gains {C:mult}+#1#{} Mult for each",
+                [2] = "unique {C:inactive}(rank-wise) {C:attention}#2#{} played",
+                [3] = "{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)"
             }
         },
         pos = {

--- a/src/data/jokers/j_balletslippers.lua
+++ b/src/data/jokers/j_balletslippers.lua
@@ -9,8 +9,11 @@ function Balatrostuck.INIT.Jokers.j_balletslippers()
         loc_txt = {
             ['name'] = 'Ballet Slippers',
             ['text'] = {
-                [1] = "Gains +5 Mult if played hand is [played hand]",
-                [2] = "hand changes every hand. Resets if a different hand is played."
+                [1] = "This Joker gains {C:mult}+#1#{} Mult",
+                [2] = "if {C:attention}poker hand{} is a {C:attention}#2#{},",
+                [3] = "poker hand changes each hand,",
+                [4] = "{C:attention}resets{} if a different hand is played",
+                [5] = "{C:inactive}(Currently {C:mult}+#3#{C:inactive} Mult)"
             }
         },
         pos = {

--- a/src/data/jokers/j_batterwitch.lua
+++ b/src/data/jokers/j_batterwitch.lua
@@ -10,9 +10,10 @@ function Balatrostuck.INIT.Jokers.j_batterwitch()
         loc_txt = {
             ['name'] = 'Batterwitch',
             ['text'] = {
-                [1] = 'If played {C:attention}Poker Hand{} is your',
-                [2] = '{C:attention}highest level{} hand, it loses',
-                [3] = '{C:attention}all{} levels and gives {C:money}$#1#{} for each level lost'
+                [1] = 'If played {C:attention}poker hand{} is',
+                [2] = 'your {C:attention}highest level{} hand, it',
+                [3] = 'loses {C:attention}all{} levels and earn',
+                [4] = '{C:money}$#1#{} for each level lost'
             }
         },
         pos = {

--- a/src/data/jokers/j_beyondcanon.lua
+++ b/src/data/jokers/j_beyondcanon.lua
@@ -1,18 +1,19 @@
+--TODO: not allowed hands thang
 function Balatrostuck.INIT.Jokers.j_beyondcanon()
     SMODS.Joker{
         name = "Beyond Canon",
         key = "beyondcanon",
         config = { extra = {
-
+            Xmult = 2
         }},
         loc_txt = {
             ['name'] = 'Beyond Canon',
             ['text'] = {
-                [1] = 'Gives {X:mult,C:white}X1.5{} Mult',
-                [2] = 'raised to power',
-                [3] = 'of current ante,',
-                [4] = 'forces 1 card to',
-                [5] = 'always be {C:attention}selected'
+                [1] = '{X:mult,C:white}X#1#{} to the power of',
+                [2] = 'current {C:attention}ante{} Mult,',
+                [3] = '{C:attention}poker hands{} played previously',
+                [4] = 'this ante are {C:red}not allowed',
+                [5] = '{C:inactive}(Currently {X:mult,C:white}X#2#{C:inactive} Mult)'
             }
         },
         pos = {
@@ -26,12 +27,16 @@ function Balatrostuck.INIT.Jokers.j_beyondcanon()
         unlocked = true,
         discovered = true,
         atlas = 'HomestuckJokers',
-        calculate = function (self, context)
-            if context.cardarea == G.jokers and not (context.individual or context.repetition or context.before or context.after) then
-                local mult = math.ceil((1.5^G.GAME.round_resets.ante)*100)/100
+
+        loc_vars = function(self, info_queue, card)
+            return { vars = { card.ability.extra.Xmult, card.ability.extra.Xmult^G.GAME.round_resets.ante} }
+        end, 
+
+        calculate = function (self, card, context)
+            if context.cardarea == G.jokers and context.joker_main then
                 return {
-                    message = localize { type = 'variable', key = 'a_xmult', vars = { mult } },
-                    Xmult_mod = mult,
+                    message = localize { type = 'variable', key = 'a_xmult', vars = { card.ability.extra.Xmult^G.GAME.round_resets.ante } },
+                    Xmult_mod = card.ability.extra.Xmult^G.GAME.round_resets.ante,
                     colour = G.C.RED
                 }
             end

--- a/src/data/jokers/j_bigkahuna.lua
+++ b/src/data/jokers/j_bigkahuna.lua
@@ -9,8 +9,8 @@ function Balatrostuck.INIT.Jokers.j_bigkahuna()
         loc_txt = {
             ['name'] = 'Big Kahuna',
             ['text'] = {
-                [1] = "After beating a blind",
-                [2] = "create a paradox lovers card"
+                [1] = "Create a {C:green}Paradox {C:attention}Lovers",
+                [2] = "card at end of round"
             }
         },
         pos = {
@@ -19,7 +19,7 @@ function Balatrostuck.INIT.Jokers.j_bigkahuna()
          },
         cost = 6,
         rarity = 1,
-        blueprint_compat = true,
+        blueprint_compat = false,
         eternal_compat = true,
         unlocked = true,
         discovered = true,

--- a/src/data/jokers/j_biscuits.lua
+++ b/src/data/jokers/j_biscuits.lua
@@ -10,7 +10,7 @@ function Balatrostuck.INIT.Jokers.j_biscuits()
         loc_txt = {
             ['name'] = 'Biscuits',
             ['text'] = {
-                [1] = "{C:green}Paradox cards{} cannot",
+                [1] = "{C:green}Paradox{} cards cannot",
                 [2] = "be destroyed"
             }
         },

--- a/src/data/jokers/j_vasterror.lua
+++ b/src/data/jokers/j_vasterror.lua
@@ -5,16 +5,17 @@ function Balatrostuck.INIT.Jokers.j_vasterror()
         config = {
             extra = {
                 rolls_needed = 7,
-                rolls = 0
+                rolls = 0,
+                valid_cards = {}
             }
         },
         loc_txt = {
             ['name'] = 'Twelve by Twelve',
             ['text'] = {
-                [1] = "Every {C:green}#1# rerolls{}, a random",
-                [2] = "card in {C:attention}deck{} gains a {C:attention}Blue Seal",
-                [3] = "and becomes {C:green}Paradox",
-                [4] = "{C:inactive}(Currently {C:attention}#2#{C:inactive}/#1#)"
+                [1] = "Every {C:green}#1# rerolls{} in the shop, add",
+                [2] = "{C:green}Paradox{} edition and a {C:blue}Blue Seal",
+                [3] = "to a {C:attention}random{} playing card in {C:attention}deck",
+                [4] = "{C:inactive}(Currently {C:attention}#2#{C:inactive}/#1# rerolls)"
             }
         },
         pos = {
@@ -37,11 +38,24 @@ function Balatrostuck.INIT.Jokers.j_vasterror()
             if context.reroll_shop and not context.blueprint then
                 card.ability.extra.rolls = card.ability.extra.rolls + 1
                 if card.ability.extra.rolls >= card.ability.extra.rolls_needed then
-                    card_eval_status_text(card, 'extra', nil, nil, nil, {message = 'Paradox-ify!',colour = G.C.GREEN, card = card})
-                    card.ability.extra.rolls = 0
-                    local _card = pseudorandom_element(G.deck.cards,pseudoseed("arcjetted"))
-                    _card:set_edition("e_bstuck_paradox",true)
-                    _card:set_seal("Blue")
+
+                    card.ability.extra.valid_cards = {}
+                    for k, v in pairs(G.deck.cards) do
+                        if not v.edition then
+                            card.ability.extra.valid_cards[#card.ability.extra.valid_cards+1] = v
+                        end
+                    end
+
+                    if card.ability.extra.valid_cards[1] then
+                        card_eval_status_text(card, 'extra', nil, nil, nil, {message = 'Paradox-ify!',colour = G.C.GREEN, card = card})
+                        card.ability.extra.rolls = 0
+                        local _card = pseudorandom_element(card.ability.extra.valid_cards,pseudoseed("arcjetted"))
+                        _card:set_edition("e_bstuck_paradox",true)
+                        _card:set_seal("Blue")
+                    else
+                        card_eval_status_text(card, 'extra', nil, nil, nil, {message = 'Miss!',colour = G.C.JOKER_GREY, card = card})
+                        card.ability.extra.rolls = 0
+                    end
                 end
             end
         end


### PR DESCRIPTION
Beyond Canon - Scoring fixed to X2^ante (still needs disallowed hands functionality)
12/12 - Properly ignores editioned cards

Description text updated for:
abraxas
ahabscrosshairs
aimlessrenegade
alltheirons
amberfirefly
applejuice
balletslippers
batterwitch
beyondcanon
bigkahuna
biscuits
vasterror
